### PR TITLE
remove deprecated distutils module for shutil.which

### DIFF
--- a/src/EsViritu/esv_funcs.py
+++ b/src/EsViritu/esv_funcs.py
@@ -13,7 +13,7 @@ from collections import Counter
 import statistics
 from typing import Dict, Tuple
 from collections import defaultdict, Counter
-from distutils.spawn import find_executable
+
 logger = logging.getLogger("esv_logger")
 
 
@@ -34,7 +34,7 @@ def str2bool(v):
 def is_tool(name):
     """Check whether `name` is on PATH."""
     
-    return find_executable(name) is not None
+    return shutil.which(name) is not None
 
 def trim_filter(reads: list, outdir: str, tempdir: str, trim: bool, filter: bool, sample_name: str,
                 filter_db: str = None, paired: str = "paired", threads: int = 4) -> list:


### PR DESCRIPTION
Hi,

Esviritu v1.0.3 installations through conda are not working properly because conda installs python 3.13 alongside, while Esviritu uses a module `distutils` which has been deprecated since v3.10 and removed since v3.12 (see [PEP-0632](https://peps.python.org/pep-0632/)). The `pyproject.toml` also only specifies that python 3.11 or greater can be used.

Instead of restricting python to v3.11, I replaced `distutils.spawn.find_executable` with `shutil.which`, which should retain the functionality but will work with newer versions of python. You will have to make a new release on bioconda for this to take effect however.
