### PR TITLE
Add optional --dedup flag for PCR duplicate removal

### DIFF
--- a/src/EsViritu/EsViritu.py
+++ b/src/EsViritu/EsViritu.py
@@ -125,10 +125,16 @@ def esviritu():
             There is no perfect metric for this."
         )
     optional_args.add_argument(
-        "--subspecies-threshold", 
-        dest="subspthresh", type=float, default=0.95, 
+        "--subspecies-threshold",
+        dest="subspthresh", type=float, default=0.95,
         help=f"Default: 0.95 -- minimum ANI of reads to reference to classify record at subspecies level.\
             There is no perfect metric for this."
+        )
+    optional_args.add_argument(
+        "--dedup",
+        dest="DEDUP", type=esvf.str2bool, default=False,
+        help='True or False. Remove PCR duplicates during fastp preprocessing? \
+            This can reduce processing time and provide more accurate abundance estimates.'
         )
     args = parser.parse_args()
 
@@ -282,7 +288,8 @@ def esviritu():
         str(filter_db_fasta),
         str(args.READ_FMT),
         str(args.CPU),
-        str(args.MMK)
+        str(args.MMK),
+        bool(args.DEDUP)
     )
 
     logger.info(f"Main input reads: {trim_filt_reads}")

--- a/src/EsViritu/esv_funcs.py
+++ b/src/EsViritu/esv_funcs.py
@@ -41,7 +41,8 @@ def is_tool(name):
     return shutil.which(name) is not None
 
 def trim_filter(reads: list, outdir: str, tempdir: str, trim: bool, filter: bool, sample_name: str,
-                filter_db: str = None, paired: str = "paired", threads: int = 4, mmk: str = "500M") -> list:
+                filter_db: str = None, paired: str = "paired", threads: int = 4, mmk: str = "500M",
+                dedup: bool = False) -> list:
     """
     Trim and/or filter .fastq reads using fastp (quality trim) and minimap2+pysam (host/spike-in filter).
     Args:
@@ -54,6 +55,7 @@ def trim_filter(reads: list, outdir: str, tempdir: str, trim: bool, filter: bool
         paired: str, "paired" or "unpaired".
         threads: int, number of threads to use.
         mmk: str, minimap2 -K parameter
+        dedup: bool, whether to remove PCR duplicates with fastp --dedup.
     Returns:
         str: path to output fastq file with processed reads.
     """
@@ -85,6 +87,8 @@ def trim_filter(reads: list, outdir: str, tempdir: str, trim: bool, filter: bool
                 "-o", trimmed1, "-O", trimmed2,
                 "-w", str(fastp_threads), "--html", fastp_html, "--json", fastp_json
             ]
+            if dedup:
+                fastp_cmd.append("--dedup")
             try:
                 subprocess.run(fastp_cmd, check=True)
             except Exception as e:
@@ -96,6 +100,8 @@ def trim_filter(reads: list, outdir: str, tempdir: str, trim: bool, filter: bool
                 "fastp", "--in1", reads[0], "--out1", trimmed_fastq,
                 "-w", str(fastp_threads), "--html", fastp_html, "--json", fastp_json
             ]
+            if dedup:
+                fastp_cmd.append("--dedup")
             try:
                 subprocess.run(fastp_cmd, check=True)
             except Exception as e:


### PR DESCRIPTION
## Summary

This PR adds an optional `--dedup` command-line flag that enables PCR duplicate removal during the fastp preprocessing step.

## Usage

```bash
# Enable deduplication
EsViritu.py -r reads_R1.fq.gz reads_R2.fq.gz -s sample -o output --dedup True

# Default behavior (no deduplication) - unchanged
EsViritu.py -r reads_R1.fq.gz reads_R2.fq.gz -s sample -o output
```

## Motivation

PCR duplicates can artificially inflate read counts and skew abundance metrics (RPKMF). Providing an optional deduplication flag allows users to obtain more accurate quantification of read support.

## Changes

- **EsViritu.py**: Added `--dedup` argument (default: False)
- **esv_funcs.py**: Added `dedup` parameter to `trim_filter()` function; conditionally appends `--dedup` to fastp commands

## Benchmark Results

Tested on an environmental sample prepared for sequencing with Illumina VSP2 with 168M read pairs:

| Metric | `--dedup False` | `--dedup True` | Change |
|--------|-----------------|----------------|--------|
| Runtime | ~49 min | ~19 min | **2.6x faster** |
| Total reads | 168M | 57.8M | -65.6% |
| Duplication rate | - | 63.9% | - |

Virus detection remained consistent with expected proportional reduction in read counts.

## Backward Compatibility

This change is fully backward compatible. The default behavior (`--dedup False`) is identical to the current release.

## Testing

- [x] Tested with paired-end reads (`--dedup True`)
- [x] Verified default behavior unchanged (`--dedup False`)
- [ ] Single-end reads (same fastp flag, expected to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)